### PR TITLE
Informationbox is placed next to phaseout meny on mobile

### DIFF
--- a/src/application.css
+++ b/src/application.css
@@ -245,9 +245,10 @@ td {
   padding: 1.5rem;
 
   @media (width <= 600px) {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-    padding: 1rem;
+    grid-template-columns: 1fr 1fr;
+    gap: 1em;
+    padding: 1em;
+    font-size: 90%;
   }
 
   .phaseout-checkboxes {
@@ -285,7 +286,6 @@ td {
   }
 
   .phaseout-total-production {
-    font-size: 1rem;
     margin-bottom: 1rem;
     display: flex;
     flex-direction: column;
@@ -334,6 +334,23 @@ td {
 @media (max-width: 600px) {
   .emission-total-projection,
   .stacked-emission-chart {
+    padding: 0.5rem;
+  }
+}
+
+.phaseout-emission-chart {
+  width: 100%;
+  max-width: 100%;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.phaseout-emission-chart canvas {
+  width: 100% !important;
+}
+
+@media (max-width: 600px) {
+  .phaseout-emission-chart {
     padding: 0.5rem;
   }
 }

--- a/src/components/charts/emissionIntensitySingleOilField.tsx
+++ b/src/components/charts/emissionIntensitySingleOilField.tsx
@@ -9,6 +9,7 @@ import {
   Title,
 } from "chart.js";
 import { Bar } from "react-chartjs-2";
+import { useIsSmallScreen } from "../../hooks/useIsSmallScreen";
 
 ChartJS.register(
   CategoryScale,
@@ -32,16 +33,22 @@ type Props = {
 };
 
 export function EmissionIntensityBarChart({ dataPoint }: Props) {
+  const isSmallScreen = useIsSmallScreen();
   const emissionIntensity = dataPoint.emissionIntensity ?? 0;
   const worldAverage = 17.5;
 
   const data = {
-    labels: [dataPoint.field, "Verdensgjennomsnitt"],
+    labels: [dataPoint.field, "Verdens gj.snitt"],
     datasets: [
       {
         label: "Utslippsintensitet",
         data: [emissionIntensity, worldAverage],
         backgroundColor: ["#3b82f6", "orange"],
+        ...(isSmallScreen
+          ? {
+              barThickness: 12,
+            }
+          : {}),
       },
     ],
   };
@@ -51,7 +58,7 @@ export function EmissionIntensityBarChart({ dataPoint }: Props) {
     plugins: {
       title: {
         display: true,
-        text: "Utslippsintensitet: Oljefelt vs. Verdensgjennomsnitt",
+        text: "Hvor skitten er produksjonen?",
         padding: {
           bottom: 20,
         },
@@ -77,5 +84,11 @@ export function EmissionIntensityBarChart({ dataPoint }: Props) {
     },
   };
 
-  return <Bar data={data} options={options} />;
+  return (
+    <Bar
+      data={data}
+      options={options}
+      height={isSmallScreen ? 400 : undefined}
+    />
+  );
 }

--- a/src/components/phaseout/phaseOutDialog.tsx
+++ b/src/components/phaseout/phaseOutDialog.tsx
@@ -133,9 +133,11 @@ export function PhaseOutDialog({ close }: { close: () => void }) {
               Utslipp i {year}:{" "}
               {fullData[latestSelectedField]?.[year]?.emission ?? "0"} Tonn Co2
             </p>
-            {fieldForChart && (
-              <EmissionIntensityBarChart dataPoint={fieldForChart!} />
-            )}
+            <div className="phaseout-emission-chart">
+              {fieldForChart && (
+                <EmissionIntensityBarChart dataPoint={fieldForChart!} />
+              )}
+            </div>
           </div>
         )}
 

--- a/src/hooks/useIsSmallScreen.tsx
+++ b/src/hooks/useIsSmallScreen.tsx
@@ -1,0 +1,15 @@
+import React, { useEffect, useState } from "react";
+
+export function useIsSmallScreen() {
+  const [isSmall, setIsSmall] = useState(() => window.innerWidth <= 600);
+
+  useEffect(() => {
+    function handleResize() {
+      setIsSmall(window.innerWidth <= 600);
+    }
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return isSmall;
+}


### PR DESCRIPTION
Information is now placed next to list of oilfields when on mobile. Chart has been redesigned to fit the screen. Added hook for checking if size is small. The hook is used inside charts to determine sizes