### PR TITLE
feat(tutorial): add onboarding, unit glossary, a11y + security harden…

### DIFF
--- a/src/application.css
+++ b/src/application.css
@@ -8,7 +8,27 @@ a {
 }
 
 dialog {
-  margin: revert;
+  margin: auto;
+}
+
+dialog::backdrop {
+  background-color: rgb(0 0 0 / 0.35);
+}
+
+.tutorial-modal {
+  width: min(640px, 92vw);
+  max-height: 85vh;
+  padding: 1rem 1.25rem;
+  border-radius: 0.25rem;
+  border: 1px solid currentColor;
+}
+
+@media (max-width: 600px) {
+  .tutorial-modal {
+    width: 94vw;
+    max-height: 88vh;
+    padding: 0.75rem 0.75rem;
+  }
 }
 
 &:disabled {

--- a/src/components/app/application.tsx
+++ b/src/components/app/application.tsx
@@ -12,6 +12,7 @@ import { ApplicationHeader } from "./applicationHeader";
 import { ApplicationFooter } from "./applicationFooter";
 import { GameOverDialog } from "./gameOverDialog";
 import { PlanRoute } from "../plan/planRoute";
+import { TutorialRoute } from "./tutorialRoute";
 
 function ApplicationRoutes() {
   return (
@@ -22,6 +23,7 @@ function ApplicationRoutes() {
       <Route path={"/plan/*"} element={<PlanRoute />} />
       <Route path={"/emissions/*"} element={<EmissionRoute />} />
       <Route path={"/production/*"} element={<ProductionRoute />} />
+      <Route path={"/tutorial"} element={<TutorialRoute />} />
       <Route path={"/summary"} element={<GameOverDialog />} />
       <Route path={"*"} element={<h2>Not Found</h2>} />
     </Routes>

--- a/src/components/app/applicationHeader.tsx
+++ b/src/components/app/applicationHeader.tsx
@@ -41,6 +41,13 @@ function ActionCard() {
         )}
       </div>
       <div>
+        <button
+          onClick={() => navigate("/tutorial", { state: { from: location } })}
+        >
+          Hvordan spiller jeg?
+        </button>
+      </div>
+      <div>
         <button onClick={restart}>Start på nytt</button>
       </div>
     </div>

--- a/src/components/app/tutorialDialog.tsx
+++ b/src/components/app/tutorialDialog.tsx
@@ -1,0 +1,144 @@
+import React, { useState } from "react";
+
+const steps = [
+  {
+    title: "Målet",
+    body: (
+      <>
+        <p>
+          Lag en plan for å fase ut olje- og gassfelter fram mot 2040. Du velger
+          hvilke felt som avvikles i hver 4-årsperiode, og ser effekten på
+          utslipp og produksjon.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "Kart og feltliste",
+    body: (
+      <>
+        <p>
+          Gå til Kart for å utforske feltene. Klikk på et felt i kartet eller i
+          listen for å se detaljer om produksjon, utslipp og intensitet.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "Måleenheter",
+    body: (
+      <>
+        <p>Litt om begrepene du ser:</p>
+        <ul>
+          <li>
+            GSm3: Standard kubikkmeter gass eller olje ved standard trykk og
+            temperatur. Brukes for å sammenligne volum.
+          </li>
+          <li>
+            «tusen tonn CO2e»: Utslipp målt i tusen tonn CO2-ekvivalenter
+            (CO2e). «e» betyr at også andre klimagasser er omregnet til CO2.
+          </li>
+          <li>
+            Utslippsintensitet (kg CO2e/BOE): Hvor mange kilo CO2-ekvivalenter
+            som slippes ut per produsert enhet energi. BOE = «barrel of oil
+            equivalent» (energiinnhold tilsvarende ett fat olje).
+          </li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    title: "Velg felter for avvikling",
+    body: (
+      <>
+        <p>
+          Trykk «Velg felter for avvikling» i toppfeltet. I dialogen kan du:
+        </p>
+        <ul>
+          <li>
+            Sortere felter etter alfabet, produksjon, utslipp eller intensitet
+          </li>
+          <li>Huke av felter som skal avvikles i inneværende periode</li>
+          <li>
+            Se summer for redusert produksjon og utslipp innen periodens slutt
+          </li>
+        </ul>
+        <p>Trykk «Fase ut valgte felter» for å gå til neste periode.</p>
+      </>
+    ),
+  },
+  {
+    title: "Se konsekvensene",
+    body: (
+      <>
+        <p>
+          Under Emissioner og Produksjon ser du grafer som oppdateres med din
+          plan. «Din plan» viser hvilke felt du allerede har avviklet.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "Fullfør og start på nytt",
+    body: (
+      <>
+        <p>
+          Når du når 2040 vises en oppsummering. Du kan når som helst starte på
+          nytt fra toppmenyen.
+        </p>
+      </>
+    ),
+  },
+];
+
+export function TutorialDialog({ onClose }: { onClose?: () => void }) {
+  const [index, setIndex] = useState(0);
+  const last = index === steps.length - 1;
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <h2>{steps[index].title}</h2>
+        <button onClick={onClose}>✖</button>
+      </div>
+      <div style={{ marginTop: "0.5rem", marginBottom: "1rem" }}>
+        {steps[index].body}
+      </div>
+      <div
+        className="button-row"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "1rem",
+        }}
+      >
+        <button
+          onClick={() => setIndex((i) => Math.max(0, i - 1))}
+          disabled={index === 0}
+        >
+          Tilbake
+        </button>
+        <span style={{ minWidth: 70, textAlign: "center" }}>
+          Steg {index + 1} / {steps.length}
+        </span>
+        {last ? (
+          <button onClick={onClose}>Ferdig</button>
+        ) : (
+          <button
+            onClick={() => setIndex((i) => Math.min(steps.length - 1, i + 1))}
+            disabled={index >= steps.length - 1}
+          >
+            Neste
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/app/tutorialRoute.tsx
+++ b/src/components/app/tutorialRoute.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Dialog } from "../ui/dialog";
+import { TutorialDialog } from "./tutorialDialog";
+
+export function TutorialRoute() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const rawFrom = (location.state as any)?.from;
+  let from = "/map";
+  if (typeof rawFrom === "string") {
+    if (rawFrom.startsWith("/")) from = rawFrom;
+  } else if (rawFrom && typeof rawFrom.pathname === "string") {
+    if (rawFrom.pathname.startsWith("/")) from = rawFrom.pathname;
+  }
+
+  return (
+    <Dialog
+      open={true}
+      onClose={() => navigate(from)}
+      className="tutorial-modal"
+    >
+      <TutorialDialog onClose={() => navigate(from)} />
+    </Dialog>
+  );
+}

--- a/src/components/phaseout/phaseOutDialog.tsx
+++ b/src/components/phaseout/phaseOutDialog.tsx
@@ -7,6 +7,7 @@ import "./phaseOut.css";
 import { mdgPlan } from "../../generated/dataMdg";
 import { fullData } from "../../data/projections";
 import { fromEntries } from "../../data/fromEntries";
+import { InfoTag } from "../ui/InfoTag";
 
 type Oilfield = {
   field: string;
@@ -248,19 +249,28 @@ export function PhaseOutDialog({
             <p>
               Oljeproduksjon i {year}:{" "}
               {fullData[latestSelectedField]?.[year]?.productionOil ?? "0"} GSm3
-              olje
+              olje{" "}
+              <InfoTag title="GSm3 = standard kubikkmeter ved standard trykk/temperatur. Brukes for å sammenligne volum.">
+                ?
+              </InfoTag>
             </p>
             <p>
               Gassproduksjon i {year}:{" "}
               {fullData[latestSelectedField]?.[year]?.productionGas ?? "0"} GSm3
-              gass
+              gass{" "}
+              <InfoTag title="GSm3 = standard kubikkmeter ved standard trykk/temperatur.">
+                ?
+              </InfoTag>
             </p>
             <p>
               Utslipp i {year}:{" "}
               {Math.round(
                 (fullData[latestSelectedField]?.[year]?.emission ?? 0) / 1000,
               )}{" "}
-              tusen tonn Co2
+              tusen tonn CO2e{" "}
+              <InfoTag title="CO2e = CO2-ekvivalenter (inkluderer andre klimagasser omregnet til CO2). ‘Tusen tonn’ betyr at tallet er delt på 1000.">
+                ?
+              </InfoTag>
             </p>
             <div className="phaseout-emission-chart">
               {fieldForChart && (
@@ -273,10 +283,23 @@ export function PhaseOutDialog({
         {Object.keys(draft).length > 0 && (
           <div className="phaseout-total-production">
             <strong>Produksjon som reduseres innen {periodEnd}:</strong>
-            <p>{totalOilProduction} GSm3 olje</p>
-            <p>{totalGasProduction} GSm3 gass</p>
+            <p>
+              {totalOilProduction} GSm3 olje{" "}
+              <InfoTag title="GSm3 = standard kubikkmeter. Viser volum ved standard forhold.">
+                ?
+              </InfoTag>
+            </p>
+            <p>
+              {totalGasProduction} GSm3 gass{" "}
+              <InfoTag title="GSm3 = standard kubikkmeter. Viser volum ved standard forhold.">
+                ?
+              </InfoTag>
+            </p>
             <strong>Utslipp som reduseres innen {periodEnd}:</strong>{" "}
-            {Math.round(totalEmission / 1_000)} tusen tonn Co2
+            {Math.round(totalEmission / 1_000)} tusen tonn CO2e{" "}
+            <InfoTag title="CO2e = CO2-ekvivalenter. ‘Tusen tonn’ = delt på 1000.">
+              ?
+            </InfoTag>
           </div>
         )}
 

--- a/src/components/ui/InfoTag.tsx
+++ b/src/components/ui/InfoTag.tsx
@@ -1,0 +1,18 @@
+import React, { ReactNode } from "react";
+
+export function InfoTag({
+  title,
+  children,
+}: {
+  title: string;
+  children?: ReactNode;
+}) {
+  return (
+    <span
+      title={title}
+      style={{ cursor: "help", borderBottom: "1px dotted currentColor" }}
+    >
+      {children ?? "(?)"}
+    </span>
+  );
+}


### PR DESCRIPTION
…ing; fix TS in dialog

•  Add /tutorial route with multi-step dialog (progress, close) •  Header: add “Hvordan spiller jeg?” button to open tutorial •  Tutorial step: explain units (GSm3, “tusen tonn CO2e”, kg CO2e/BOE) •  Inline unit tooltips (InfoTag) in phase-out dialog •  Dialog improvements:
•  Backdrop-only outside-click close
•  Guard showModal/close to avoid double calls
•  Esc-to-close, focus trapping, and initial focus •  TypeScript nullability fix in backdrop handler
•  Navigation safety: sanitize “from” to internal paths only •  Styling: align tutorial modal to app theme (border radius, colors, spacing) and subtle backdrop

Files:
•  components/app: application.tsx, applicationHeader.tsx, tutorialRoute.tsx, tutorialDialog.tsx
•  components/ui: dialog.tsx, InfoTag.tsx (new)
•  components/phaseout: phaseOutDialog.tsx
•  application.css